### PR TITLE
Generator should include a theme in Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ far. Feel free to submit a pull request to add to this list.
 
 |Theme          |Repository URL                                                      |
 |---------------|--------------------------------------------------------------------|
-|Generic Theme  |http://github.com/NCSU-Libraries/quicksearch-generic_theme          |
+|Generic Theme  |http://github.com/NCSU-Libraries/quick_search-generic_theme          |
 
 
 ## TODO


### PR DESCRIPTION
The generator should include a theme in the Gemfile. Goal is to allow either skipping or minimizing the manual configuration steps in order to get a quick_search application that doesn't error out when started up. Currently the generated quick_search_config.yml expects the generic theme to be present. The generator could include the generic theme in the Gemfile and include documentation both in the Gemfile and the quick_search_config.yml file about installing or creating another theme.
