### PR TITLE
generated config should only include installed searchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ development.
 
     bundle exec rails generate quick_search:install
 
-##### Configure QuickSearch (see [Configuring QuickSearch](docs/configuration.md))
+The generator will install the generic QuickSearch theme, and some
+searchers that will work out of the box. For more information on further
+configuring QuickSearch, see: [Configuring QuickSearch](docs/configuration.md)
 
 ##### Start the server:
 

--- a/app/controllers/concerns/quick_search/searcher_config.rb
+++ b/app/controllers/concerns/quick_search/searcher_config.rb
@@ -8,8 +8,11 @@ module QuickSearch::SearcherConfig
     if searcher == 'best_bets'
       QuickSearch::Engine::APP_CONFIG['best_bets']
     else
-      #TODO: test for the existence of this?
-      "QuickSearch::Engine::#{searcher.upcase}_CONFIG".constantize
+      begin
+        "QuickSearch::Engine::#{searcher.upcase}_CONFIG".constantize
+      rescue NameError
+        nil
+      end
     end
   end
 

--- a/lib/generators/quick_search/install_generator.rb
+++ b/lib/generators/quick_search/install_generator.rb
@@ -11,10 +11,12 @@ ROUTES
         insert_into_file "config/routes.rb", routes, :after => "Rails.application.routes.draw do\n"
       end
 
+
       desc 'insert generic theme'
       def insert_theme
+
         theme_gem_entry = <<-THEME
-\n\n
+\n
 # -Inserted by QuickSearch-
 
 # QuickSearch theme
@@ -22,6 +24,30 @@ ROUTES
 # Remove the following if you want to use a different theme
 
 gem 'quick_search-generic_theme'
+
+# END -Inserted by QuickSearch-
+
+THEME
+
+
+        say("\nYou'll need to include a theme which QuickSearch uses to render your results. We've built a generic
+theme which can be modified or extended to meet your needs. Alternatively you can build your own from
+scratch and include it.\n\n")
+
+        @theme_response = ask("Would you like to install the generic theme?", limited_to: ['y', 'n'])
+
+        if @theme_response == 'y'
+          insert_into_file "Gemfile", theme_gem_entry, :after => /gem [\"\']quick_search-core[\"\'].*$/
+        end
+
+      end
+
+
+      desc 'insert searchers'
+      def insert_searchers
+        searcher_gem_entry = <<-SEARCHERS
+\n
+# -Inserted by QuickSearch-
 
 # QuickSearch searchers
 #
@@ -36,9 +62,22 @@ gem 'quick_search-placeholder_searcher'
 
 # -END Inserted by QuickSearch-
 
-        THEME
-        insert_into_file "Gemfile", theme_gem_entry, :after => /gem [\"\']quick_search-core[\"\'].*$/
+        SEARCHERS
+
+        say("\nTo have a working application you'll need to install some searchers. Searchers are the
+code that integrates with third-party APIs, handles performing searches and creating results objects.
+By default quick_search-core provides no searchers. Some searchers are available and it is easy to
+write your own.\n\n")
+
+
+        @searcher_response = ask("Would you like to install some basic searchers that do not require API keys?", limited_to: ['y', 'n'])
+
+        if @searcher_response == 'y'
+          insert_into_file "Gemfile", searcher_gem_entry, :after => /gem [\"\']quick_search-core[\"\'].*$/
+        end
+
       end
+
 
       desc 'bundle install theme/searchers'
       def bundle_install_theme_searchers
@@ -76,6 +115,13 @@ gem 'quick_search-placeholder_searcher'
 
       desc 'display messages about what needs to be configured'
       def configuration_messages
+        say "QuickSearch installation complete.\n\n", :green
+        if @searcher_response == 'y'
+          say "We've installed a set of default searchers.\n", :green
+        end
+        if @theme_response == 'y'
+          say "We've installed the generic theme.\n", :green
+        end
         file = File.read(File.join( File.expand_path('../templates', __FILE__), 'post_install.txt'))
         say file, :green
       end

--- a/lib/generators/quick_search/install_generator.rb
+++ b/lib/generators/quick_search/install_generator.rb
@@ -21,7 +21,7 @@ ROUTES
 #
 # Remove the following if you want to use a different theme
 
-gem 'quick_search_generic_theme', git: 'git@github.com:ncsu-libraries/quick_search-generic_theme.git'
+gem 'quick_search-generic_theme'
 
 # QuickSearch searchers
 #
@@ -29,10 +29,10 @@ gem 'quick_search_generic_theme', git: 'git@github.com:ncsu-libraries/quick_sear
 # your config/quick_search_config.yml file as well as references to them in your theme's search
 # results page template
 
-gem 'quick_search_wikipedia_searcher', git: 'git@github.com:ncsu-libraries/quick_search-wikipedia_searcher.git'
-gem 'quick_search_open_library_searcher', git: 'git@github.com:ncsu-libraries/quick_search-open_library_searcher.git'
-gem 'quick_search_arxiv_searcher', git: 'git@github.com:ncsu-libraries/quick_search-arxiv_searcher.git'
-gem 'quick_search_placeholder_searcher', git: 'git@github.com:ncsu-libraries/quick_search-placeholder_searcher.git'
+gem 'quick_search-wikipedia_searcher'
+gem 'quick_search-open_library_searcher'
+gem 'quick_search-arxiv_searcher'
+gem 'quick_search-placeholder_searcher'
 
 # -END Inserted by QuickSearch-
 

--- a/lib/generators/quick_search/install_generator.rb
+++ b/lib/generators/quick_search/install_generator.rb
@@ -91,6 +91,20 @@ write your own.\n\n")
         copy_file 'quick_search_config.yml', 'config/quick_search_config.yml'
       end
 
+      desc 'update quick_search_config.yml'
+      def update_quick_search_config
+        if @theme_response == 'y'
+          theme_config = 'quick_search_generic_theme'
+          insert_into_file "config/quick_search_config.yml", theme_config, :after => /^  theme: '/
+        end
+        if @searcher_response == 'y'
+          included_searchers = ',arxiv,open_library,wikipedia,placeholder'
+          included_found_types = 'arxiv,open_library,wikipedia,placeholder,placeholder,placeholder,placeholder'
+          insert_into_file "config/quick_search_config.yml", included_searchers, :after => /^  searchers: \[best_bets/
+          insert_into_file "config/quick_search_config.yml", included_found_types, :after => /^  found_types: \[/
+        end
+      end
+
       desc 'create kaminari initializer'
       def kaminari_initializer
         copy_file 'kaminari.rb', 'config/initializers/kaminari.rb'

--- a/lib/generators/quick_search/install_generator.rb
+++ b/lib/generators/quick_search/install_generator.rb
@@ -11,6 +11,42 @@ ROUTES
         insert_into_file "config/routes.rb", routes, :after => "Rails.application.routes.draw do\n"
       end
 
+      desc 'insert generic theme'
+      def insert_theme
+        theme_gem_entry = <<-THEME
+\n\n
+# -Inserted by QuickSearch-
+
+# QuickSearch theme
+#
+# Remove the following if you want to use a different theme
+
+gem 'quick_search_generic_theme', git: 'git@github.com:ncsu-libraries/quick_search-generic_theme.git'
+
+# QuickSearch searchers
+#
+# If you want to use different searchers, remove/replace these and be sure to remove them from
+# your config/quick_search_config.yml file as well as references to them in your theme's search
+# results page template
+
+gem 'quick_search_wikipedia_searcher', git: 'git@github.com:ncsu-libraries/quick_search-wikipedia_searcher.git'
+gem 'quick_search_open_library_searcher', git: 'git@github.com:ncsu-libraries/quick_search-open_library_searcher.git'
+gem 'quick_search_arxiv_searcher', git: 'git@github.com:ncsu-libraries/quick_search-arxiv_searcher.git'
+gem 'quick_search_placeholder_searcher', git: 'git@github.com:ncsu-libraries/quick_search-placeholder_searcher.git'
+
+# -END Inserted by QuickSearch-
+
+        THEME
+        insert_into_file "Gemfile", theme_gem_entry, :after => /gem [\"\']quick_search-core[\"\'].*$/
+      end
+
+      desc 'bundle install theme/searchers'
+      def bundle_install_theme_searchers
+        Bundler.with_clean_env do
+          run "bundle install"
+        end
+      end
+
       desc 'create application configuration file'
       def quick_search_config_yml
         copy_file 'quick_search_config.yml', 'config/quick_search_config.yml'

--- a/lib/generators/quick_search/templates/post_install.txt
+++ b/lib/generators/quick_search/templates/post_install.txt
@@ -1,6 +1,3 @@
-QuickSearch installation complete.
-
-We've installed a generic theme and a few searchers that will work out of the box.
 
 To add/remove/replace searchers:
 
@@ -10,3 +7,4 @@ To add/remove/replace searchers:
 4. Add render_module calls to search results view for each searcher
 
 For more information, see README and other documentation at http://github.com/ncsu-libraries/quick_search/
+

--- a/lib/generators/quick_search/templates/post_install.txt
+++ b/lib/generators/quick_search/templates/post_install.txt
@@ -1,4 +1,8 @@
-QuickSearch installation complete. To add searchers:
+QuickSearch installation complete.
+
+We've installed a generic theme and a few searchers that will work out of the box.
+
+To add/remove/replace searchers:
 
 1. Add searcher gems (see README for list of gems) to your project's Gemfile
 2. Add a theme gem to Gemfile (see README)

--- a/lib/generators/quick_search/templates/quick_search_config.yml
+++ b/lib/generators/quick_search/templates/quick_search_config.yml
@@ -7,7 +7,7 @@ defaults: &defaults
   #
   # See docs for more details: https://github.com/NCSU-Libraries/quick_search/blob/master/docs/configuration.md
 
-  theme: 'quick_search_generic_theme'
+  theme: ''
 
   # Searchers that QuickSearch will automatically search
   #
@@ -18,11 +18,11 @@ defaults: &defaults
   #
   # See docs for more details: https://github.com/NCSU-Libraries/quick_search/blob/master/docs/configuration.md
 
-  searchers: [best_bets,arxiv,open_library,wikipedia,placeholder]
+  searchers: [best_bets]
 
   # Searchers listed in the "result type guide" bar that lists result types that were found for a given search
 
-  found_types: [arxiv,open_library,wikipedia,placeholder,placeholder,placeholder,placeholder]
+  found_types: []
 
   per_page: 3
   max_per_page: 50

--- a/lib/generators/quick_search/templates/quick_search_config.yml
+++ b/lib/generators/quick_search/templates/quick_search_config.yml
@@ -1,7 +1,29 @@
 defaults: &defaults
+
+  # QuickSearch theme name
+  #
+  # To use a different theme, you must first add a new theme gem to the Gemfile,
+  # run 'bundle install', then update this with the new theme name.
+  #
+  # See docs for more details: https://github.com/NCSU-Libraries/quick_search/blob/master/docs/configuration.md
+
   theme: 'quick_search_generic_theme'
+
+  # Searchers that QuickSearch will automatically search
+  #
+  # To use different searchers, you must first add the new searcher gem to the Gemfile,
+  # run 'bundle install', then add the searcher name to this list. You must also
+  # add a 'render_module()' helper call to your search results page tempate to expose the
+  # results for that searcher.
+  #
+  # See docs for more details: https://github.com/NCSU-Libraries/quick_search/blob/master/docs/configuration.md
+
   searchers: [best_bets,arxiv,open_library,wikipedia,placeholder]
+
+  # Searchers listed in the "result type guide" bar that lists result types that were found for a given search
+
   found_types: [arxiv,open_library,wikipedia,placeholder,placeholder,placeholder,placeholder]
+
   per_page: 3
   max_per_page: 50
   http_timeout: 1.5


### PR DESCRIPTION
Currently the generated quick_search_config.yml includes searchers which aren't included in the Gemfile when the generator is run. The default generated config could do one of the following among other options:

1. Only include the placeholder searcher.
2. Add searchers that do not require an API key to the Gemfile when the generator is run. Also include some documentation in the Gemfile about removing these later.
3. The generator could if the user wants some demo searchers installed and installs them as a group or not at all.
4. The generator could ask if the user wants to install one or more searchers ala carte. This could be a from a list of all known searchers and can note whether the searcher will need extra config or not.

Goal should be to minimize the amount of worked needed to be done in this step:
https://github.com/NCSU-Libraries/quick_search#configure-quicksearch-see-configuring-quicksearch

As an initial pass at improving this I'm leaning towards option 2. Thoughts, @kbeswick ?