### PR TITLE
Avoid bundle exec for rails command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ configuring QuickSearch, see: [Configuring QuickSearch](docs/configuration.md)
 
 ##### Start the server:
 
-    bundle exec rails s
+    rails s
 
 ##### QuickSearch will be available at http://localhost:3000/
 


### PR DESCRIPTION
Rails checks the presence of Bundler through the Gemfile and avoids the overhead

https://wyeworks.com/blog/2011/12/27/bundle-exec-rails-executes-bundler-setup-3-times/