### PR TITLE
Pass quick_search_config.yml file through ERB processor

### DIFF
--- a/lib/quick_search/engine.rb
+++ b/lib/quick_search/engine.rb
@@ -15,7 +15,7 @@ module QuickSearch
     initializer :quick_search, :after => :add_view_paths do
       config_file = File.join(Rails.root, "/config/quick_search_config.yml")
       if File.exist?(config_file)
-        QuickSearch::Engine::APP_CONFIG = YAML.load_file(config_file)[Rails.env]
+        QuickSearch::Engine::APP_CONFIG = YAML.load(ERB.new(File.read(config_file)).result)[Rails.env]
         ActiveSupport.on_load(:action_controller) do
           # get theme / core engine classes
           theme_engine_class = "#{QuickSearch::Engine::APP_CONFIG['theme'].classify}::Engine".constantize


### PR DESCRIPTION
The quick_search_config.yml file contains some properties that
might differ on a dev server vs. a production server. For example,
the Best Bets "solr_url" property might point to a dev Solr instance
from a dev server, and a production Solr instance on a production
server.

Is it often convenient to provide such information via environment
variables that are passed into Rails. This pull request modifies
the processing of the config/quick_search_config.yml file to pass
it through the ERB template processor. ERB directives such as
"<%= ENV['SOLR_URL'] %>" can then be added to the file, to enable
environment variables to be utilized.