### PR TITLE
Make "loaded_link" and "no_results_link" more configurable

### DIFF
--- a/app/controllers/concerns/quick_search/searcher_concern.rb
+++ b/app/controllers/concerns/quick_search/searcher_concern.rb
@@ -6,6 +6,7 @@ module QuickSearch::SearcherConcern
   include QuickSearch::EncodeUtf8
   include QuickSearch::SearcherConfig
   require 'benchmark_logger'
+  require_dependency 'searcher_error'
 
   private
 
@@ -60,8 +61,12 @@ module QuickSearch::SearcherConcern
               instance_variable_set "@#{sm}", searcher
             rescue StandardError => e
               # logger.info e
+
+              # Wrap e in a SearcherError, so that the searcher object is
+              # available for retrieval.
+              searcher_error = QuickSearch::SearcherError.new(e, searcher)
               logger.info "FAILED SEARCH: #{sm} | #{params_q_scrubbed}"
-              instance_variable_set :"@#{sm.to_s}", e
+              instance_variable_set :"@#{sm.to_s}", searcher_error
             end
           end
         end

--- a/app/searchers/quick_search/searcher.rb
+++ b/app/searchers/quick_search/searcher.rb
@@ -47,6 +47,26 @@ module QuickSearch
       end
     end
 
+    # Returns the "loaded_link" when an error occurs, either from an I18N locale
+    # file, or the "loaded_link" method on the searcher.
+    #
+    # Using the I18N locale files is considered legacy behavior (but
+    # is preferred in this method to preserve existing functionality).
+    #
+    # Parameters:
+    #  - service_name: The name of the searcher as used by the I18N locale files
+    #  - error: The StandardError/SearcherError object
+    #  - query: The search term being queried
+    def self.module_link_on_error(service_name, error, query)
+      if I18n.exists?("#{service_name}_search.loaded_link")
+        # Preserve legacy behavior of using "loaded_link" from I18n locale file
+        return I18n.t("#{service_name}_search.loaded_link") + ERB::Util.url_encode("#{query}")
+      elsif error.is_a? QuickSearch::SearcherError
+        searcher_obj = error.searcher
+        return searcher_obj.loaded_link
+      end
+    end
+
     private
 
     def http_request_queries

--- a/app/searchers/quick_search/searcher.rb
+++ b/app/searchers/quick_search/searcher.rb
@@ -25,6 +25,28 @@ module QuickSearch
       raise #FIXME: pick some good error
     end
 
+    # Returns a String representing the link to use when no results are
+    # found for a search.
+    #
+    # This default implementation first looks for the "i18n_key" and
+    # "default_i18n_key" in the I18N locale files. If no entry is found
+    # the "no_results_link" from the searcher configuration is returned.
+    #
+    # Using the I18N locale files is considered legacy behavior (but
+    # is preferred in this method to preserve existing functionality).
+    # Use of the searcher configuration file is preferred.
+    def no_results_link(service_name, i18n_key, default_i18n_key = nil)
+      locale_result = I18n.t(i18n_key, default: I18n.t(default_i18n_key))
+      return locale_result if locale_result
+
+      begin
+        config_class = "QuickSearch::Engine::#{service_name.upcase}_CONFIG".constantize
+        config_class['no_results_link']
+      rescue NameError
+        nil
+      end
+    end
+
     private
 
     def http_request_queries

--- a/app/views/quick_search/search/_module.html.erb
+++ b/app/views/quick_search/search/_module.html.erb
@@ -1,13 +1,7 @@
 <div id="<%= service_name.dasherize %>" class="module-contents" >
     <% if searcher.is_a? StandardError %>
 
-        <% if I18n.exists?("#{service_name}_search.loaded_link") %>
-            <%# Preserve legacy behavior of using "loaded_link" from I18n locale file %>
-            <% module_link = t("#{service_name}_search.loaded_link") + url_encode("#{@query}") %>
-        <% elsif searcher.is_a? QuickSearch::SearcherError %>
-            <% searcher_obj = searcher.searcher %>
-            <% module_link = searcher_obj.loaded_link %>
-        <% end %>
+        <% module_link = QuickSearch::Searcher.module_link_on_error(service_name, searcher, @query) %>
 
         <h2 class="result-set-heading"><%= module_display_name %></h2>
         <% if params[:page].blank? %>

--- a/app/views/quick_search/search/_module.html.erb
+++ b/app/views/quick_search/search/_module.html.erb
@@ -1,15 +1,24 @@
 <div id="<%= service_name.dasherize %>" class="module-contents" >
     <% if searcher.is_a? StandardError %>
+
+        <% if I18n.exists?("#{service_name}_search.loaded_link") %>
+            <%# Preserve legacy behavior of using "loaded_link" from I18n locale file %>
+            <% module_link = t("#{service_name}_search.loaded_link") + url_encode("#{@query}") %>
+        <% elsif searcher.is_a? QuickSearch::SearcherError %>
+            <% searcher_obj = searcher.searcher %>
+            <% module_link = searcher_obj.loaded_link %>
+        <% end %>
+
         <h2 class="result-set-heading"><%= module_display_name %></h2>
         <% if params[:page].blank? %>
             <% page = 1 %>
         <% else %>
             <% page = params[:page] %>
         <% end %>
-        <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'without_paging' } %>
+        <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'without_paging',  module_link: module_link } %>
     <% elsif searcher.results.blank? %>
         <h2 class="result-set-heading"><%= module_display_name %></h2>
-        <%= render partial: '/quick_search/search/no_results', locals: {module_display_name: module_display_name, service_name: service_name} %>
+        <%= render partial: '/quick_search/search/no_results', locals: {module_display_name: module_display_name, service_name: service_name, searcher: searcher} %>
     <% else %>
         <% total = number_with_delimiter(searcher.total) %>
         <% unless defined? searcher.loaded_link_mobile %>

--- a/app/views/quick_search/search/_module_with_paging.html.erb
+++ b/app/views/quick_search/search/_module_with_paging.html.erb
@@ -1,13 +1,6 @@
 <div id="<%= service_name.dasherize %>" class="module-contents" data-turbolinks="false">
     <% if searcher.is_a? StandardError %>
-
-        <% if I18n.exists?("#{service_name}_search.loaded_link") %>
-            <%# Preserve legacy behavior of using "loaded_link" from I18n locale file %>
-            <% module_link = t("#{service_name}_search.loaded_link") + url_encode("#{@query}") %>
-        <% elsif searcher.is_a? QuickSearch::SearcherError %>
-            <% searcher_obj = searcher.searcher %>
-            <% module_link = searcher_obj.loaded_link %>
-        <% end %>
+        <% module_link = QuickSearch::Searcher.module_link_on_error(service_name, searcher, @query) %>
 
         <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'with_paging', module_link: module_link } %>
     <% elsif searcher.results.blank? %>

--- a/app/views/quick_search/search/_module_with_paging.html.erb
+++ b/app/views/quick_search/search/_module_with_paging.html.erb
@@ -1,8 +1,17 @@
 <div id="<%= service_name.dasherize %>" class="module-contents" data-turbolinks="false">
     <% if searcher.is_a? StandardError %>
-        <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'with_paging' } %>
+
+        <% if I18n.exists?("#{service_name}_search.loaded_link") %>
+            <%# Preserve legacy behavior of using "loaded_link" from I18n locale file %>
+            <% module_link = t("#{service_name}_search.loaded_link") + url_encode("#{@query}") %>
+        <% elsif searcher.is_a? QuickSearch::SearcherError %>
+            <% searcher_obj = searcher.searcher %>
+            <% module_link = searcher_obj.loaded_link %>
+        <% end %>
+
+        <%= render partial: '/quick_search/search/search_error', locals: { service_name: service_name, page: page, template: 'with_paging', module_link: module_link } %>
     <% elsif searcher.results.blank? %>
-        <%= render partial: '/quick_search/search/no_results', locals: { :service_name => service_name } %>
+        <%= render partial: '/quick_search/search/no_results', locals: { :service_name => service_name, searcher: searcher } %>
     <% else %>
         <% total = number_with_delimiter(searcher.total) %>
         <p>Page <%= page %> of <%= total %> <%= t("#{service_name}_search.short_display_name")  %> results</p>

--- a/app/views/quick_search/search/_no_results.html.erb
+++ b/app/views/quick_search/search/_no_results.html.erb
@@ -1,11 +1,11 @@
 <p class='search-error-message'><i class="fa fa-info-circle"></i> No <%= t("#{service_name}_search.short_display_name") %> results found for <span class="query"><%= display_query %></span></p>
 <p class="see-all-results show-for-medium-up">
-    <%= link_to t("#{service_name}_search.no_results_link"), data: {"quicksearch_ga_action" => "no-results"} do %>
+    <%= link_to searcher.no_results_link(service_name, "#{service_name}_search.no_results_link"), data: {"quicksearch_ga_action" => "no-results"} do %>
         <i class="fa fa-angle-right"></i> Try <%= t("#{service_name}_search.no_results_service_message") %>
     <% end %>
 </p>
 <p class="see-all-results show-for-small-only">
-    <%= link_to t("#{service_name}_search.no_results_link_mobile", :default => t("#{service_name}_search.no_results_link")), data: {"quicksearch_ga_action" => "no-results"} do %>
+    <%= link_to searcher.no_results_link(service_name, "#{service_name}_search.no_results_link_mobile", "#{service_name}_search.no_results_link"), data: {"quicksearch_ga_action" => "no-results"} do %>
         <i class="fa fa-angle-right"></i> Try <%= t("#{service_name}_search.no_results_service_message") %>
     <% end %>
 </p>

--- a/app/views/quick_search/search/_search_error.html.erb
+++ b/app/views/quick_search/search/_search_error.html.erb
@@ -1,9 +1,9 @@
-<p class="search-error" data-quicksearch-search-endpoint="<%= service_name %>" 
+<p class="search-error" data-quicksearch-search-endpoint="<%= service_name %>"
     data-quicksearch-page="<%= page %>"
     data-quicksearch-template="<%= template %>"></p>
 <p class="search-error-rescue search-error-message"><i class="fa fa-warning"></i> We're sorry. This search took too long.</p>
 <p class="search-error-rescue see-all-results">
-    <%= link_to t("#{service_name}_search.loaded_link") + url_encode("#{@query}"), data: {"quicksearch_ga_action" => "error"} do %>
+    <%= link_to module_link, data: {"quicksearch_ga_action" => "error"} do %>
     <i class="fa fa-angle-right"></i> Try <%= t("#{service_name}_search.error_service_message") %> for <span class='query'>"<%= truncate(@query, length: 100, separator: ' ') %>"</span>
     <% end %>
 </p>

--- a/lib/searcher_error.rb
+++ b/lib/searcher_error.rb
@@ -1,0 +1,12 @@
+# StandardError wrapper that enables the affected searcher to be specified
+module QuickSearch
+  class SearcherError < StandardError
+    attr_reader :searcher
+
+    def initialize(e=nil, searcher)
+      super e
+      @searcher = searcher
+      set_backtrace e.backtrace if e
+    end
+  end
+end

--- a/test/searcher/searcher_test.rb
+++ b/test/searcher/searcher_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class SearcherTest < ActiveSupport::TestCase
+  def setup
+    # Clear any "test_search" setting in I18N
+    I18n.backend.store_translations(:en, {test_search: {loaded_link: nil} })
+  end
+
+  test 'module_link_on_error should return nil on StandardError if no I18N value is given' do
+    error = StandardError.new
+    module_link = QuickSearch::Searcher.module_link_on_error('test', error, '_sample_query')
+    assert module_link.nil?
+  end
+
+  test 'module_link_on_error should return I18N value on StandardError' do
+    I18n.backend.store_translations(:en, {test_search: {loaded_link: 'from I18N'} })
+    error = StandardError.new
+    module_link = QuickSearch::Searcher.module_link_on_error('test', error, '_sample_query')
+    assert_equal 'from I18N_sample_query', module_link
+  end
+
+  test 'module_link_on_error should return I18N value if present on SearcherError' do
+    I18n.backend.store_translations(:en, {test_search: {loaded_link: 'from I18N'} })
+    searcher = SearcherTest::TestSearcher.new
+    error = QuickSearch::SearcherError.new(StandardError.new, searcher)
+    module_link = QuickSearch::Searcher.module_link_on_error('test', error, '_sample_query')
+    assert_equal 'from I18N_sample_query', module_link
+  end
+
+  test 'module_link_on_error should use loaded_link method if I18N value is not present on SearcherError' do
+    searcher = SearcherTest::TestSearcher.new
+    error = QuickSearch::SearcherError.new(StandardError.new, searcher)
+    module_link = QuickSearch::Searcher.module_link_on_error('test', error, 'sample query')
+    assert_equal 'test_loaded_link', module_link
+  end
+end
+
+# Simple test searcher
+class SearcherTest::TestSearcher < QuickSearch::Searcher
+  def initialize
+  end
+
+  def loaded_link
+    'test_loaded_link'
+  end
+end


### PR DESCRIPTION
The "loaded_link" provides a link to the native search interface,
with the current search pre-populated. The "no_results_link" provides
a link to the native search interface when no search results are found.

In the sample searchers, such as "quick_search-placeholder_searcher"
(https://github.com/NCSU-Libraries/quick_search-placeholder_searcher)
the "loaded_link" is defined both in the I18N locale file
(config/locales/en.yml file), and in a "loaded_link" method in the
implementation of the Searcher base class
(app/searchers/quick_search/placeholder_searcher.rb)

So in the GUI, can be "loaded_link" is retrieved from two different
places:

1) The "loaded_link" property from the I18N locale file is used in the
following view helpers:

* quick_search/app/views/quick_search/search/_search_error.html.erb
* quick_search/app/views/quick_search/search/_no_results.html.erb

2) The "loaded_link" method from the searcher class is used in the
"quick_search/app/views/quick_search/search/_module.html.erb" view
helper.

Having a "loaded_link" property in the en.yml file, and a "loaded_link"
method in the searcher is confusing, as it is unclear without examining
the code, which instance is used where. It is even more problematic,
because the return value from the "loaded_link" method may contain
additional processing that is not possible with the "loaded_link"
property.

The I18N locale files also have a "no_results_link" property. There is
no associated "no_results_link" method on the searcher, so this property
cannot always reflect the same URL as the "loaded_link" generated by the
method.

From a larger perspective, having the "loaded_link" and
"no_results_link" properties in the I18N locale file is not ideal,
because it makes it difficult to configure these properties on
a per-server basis. For example, a "dev" machine might have searchers
configured to point to other development machines, while a "production"
machine would have searchers pointing to other production machines.
Since the I18N locale file can't be easily configured via server
environment variables, the file needs to be manually changed on either
the dev or production machine (depending on which version of the en.yml
file is checked into the Git repository).

The provided solution does the following:

1) Change the templates and code so that the "loaded_link" shown in the
   GUI comes exclusively from the "loaded_link" method of the searcher.

2) Change the templates and code so that a "no_results_link" method is
   available and used in the GUI.

3) For backward compatibility, preserve the existing behavior of
   retrieving "load_link" and "no_results_link" values from the
   I18N locale file, unless the properties in the file are nil, in
   which case use the appropriate method.

This would help in a number of ways:

1) It would make the code less confusing, and reduce duplication
   regarding the "loaded_link" instance.

2) It would enable the searcher to handle generating the links,
   including the ability to use more flexible mechanism such as
   environment variables, via the searcher configuration YAML files.

Note: Both "loaded_link" and "no_results_link" have associated "mobile"
versions, i.e. "loaded_link_mobile" and "no_results_link_mobile". The
"mobile" versions appear to be unused (or fall back to the "loaded_link"
property, if necessary), and so are not changed by the following.

----

Implementation Notes

In the existing implementation, the result of the "loaded_link" method
is displayed in the GUI when there is a successful search with results.
The "loaded_link" property from the I18N locale files is displayed when
a searcher error occurs.

The "loaded_link" property from the I18N locale file is used for
failed searches because the "search_all_in_threads" method of
SearcherConcern class returns an instance variable (named after the
searcher) that contains either the searcher object itself (if no error
occurs), or a StandardError (if an error occurs). The presence of
a StandardError in the instance variable triggers the appropriate
display in the view templates, but does not include a reference to the
searcher itself.

The code has been changed to enable the "loaded_link" method of the
searcher to be called even when there is an error. It does this by
wrapping the StandardError returned by the "search_all_in_threads"
method in a "SearcherError" class (which itself extends StandardError),
providing an accessor for retrieving the searcher. If an error has
occurred, the searcher is available to the ERB template, so that
the "loaded_link" method can be called.

In order to preserve the existing behavior of utilizing the
"loaded_link" property from the I18N locale file, logic has been placed
in the ERB templates to prefer the I18N property (if it exists) over
the "loaded_link" method of the searcher for failed searches.

For the "no_results_link", this implementation adds a "no_results_link"
method to the QuickSearch::Searcher base class. The class provides a
default implementation that preserves the existing behavior of
retrieving the "no_results_link" value from the I18N locale files, but
also adds the ability to retrieve the value from the searcher
configuration file.