### PR TITLE
Fixed "no_results_link" handling for I18N fallback

### DIFF
--- a/app/searchers/quick_search/searcher.rb
+++ b/app/searchers/quick_search/searcher.rb
@@ -36,8 +36,11 @@ module QuickSearch
     # is preferred in this method to preserve existing functionality).
     # Use of the searcher configuration file is preferred.
     def no_results_link(service_name, i18n_key, default_i18n_key = nil)
-      locale_result = I18n.t(i18n_key, default: I18n.t(default_i18n_key))
-      return locale_result if locale_result
+      if (i18n_key.present? && I18n.exists?(i18n_key)) ||
+         (default_i18n_key.present? && I18n.exists?(default_i18n_key))
+        locale_result = I18n.t(i18n_key, default: I18n.t(default_i18n_key))
+        return locale_result if locale_result
+      end
 
       begin
         config_class = "QuickSearch::Engine::#{service_name.upcase}_CONFIG".constantize

--- a/test/searcher/searcher_test.rb
+++ b/test/searcher/searcher_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require_dependency 'searcher_error'
 
 class SearcherTest < ActiveSupport::TestCase
   def setup
@@ -32,6 +33,84 @@ class SearcherTest < ActiveSupport::TestCase
     error = QuickSearch::SearcherError.new(StandardError.new, searcher)
     module_link = QuickSearch::Searcher.module_link_on_error('test', error, 'sample query')
     assert_equal 'test_loaded_link', module_link
+  end
+
+  test 'no_results_link should use "no_results_link" method if I18N value is not present' do
+    # Set Searcher Configuration value
+    QuickSearch::Engine::TEST_CONFIG = { 'no_results_link' => 'from config' }
+
+    # Enable I18n fallback (simulates config.i18n.fallbacks=true)
+    I18n::Backend::Simple.include(I18n::Backend::Fallbacks)
+    I18n.fallbacks= {:en=>[:en]}
+
+    # I18n key is not in I18n configuration
+    searcher = SearcherTest::TestSearcher.new
+    no_results_link = searcher.no_results_link('test', 'test_search.no_results_link')
+    assert_equal 'from config', no_results_link
+
+    # I18n key is nil
+    searcher = SearcherTest::TestSearcher.new
+    no_results_link = searcher.no_results_link('test', nil)
+    assert_equal 'from config', no_results_link
+
+    # I18n default key is not in I18n configuration
+    searcher = SearcherTest::TestSearcher.new
+    no_results_link = searcher.no_results_link(
+      'test', 'test_search.no_results_link', 'test_search.default_no_results_link')
+    assert_equal 'from config', no_results_link
+
+    # I18n default key is nil
+    searcher = SearcherTest::TestSearcher.new
+    no_results_link = searcher.no_results_link('test', nil, nil)
+    assert_equal 'from config', no_results_link
+  end
+
+  test 'no_results_link should use I18N value if present' do
+    # Set Searcher Configuration value
+    QuickSearch::Engine::TEST_CONFIG = { 'no_results_link' => 'from config' }
+
+    # Set I18N value
+    I18n.backend.store_translations(:en,
+      {test_search: {no_results_link: 'from I18N', default_no_results_link: 'from default I18N'} })
+
+    # When default I18N key is not specified
+    searcher = SearcherTest::TestSearcher.new
+    no_results_link = searcher.no_results_link('test', 'test_search.no_results_link')
+    assert_equal 'from I18N', no_results_link
+
+    # When default I18N key is specified, and exists
+    searcher = SearcherTest::TestSearcher.new
+    no_results_link = searcher.no_results_link(
+      'test', 'test_search.no_results_link', 'test_search.default_no_results_link')
+    assert_equal 'from I18N', no_results_link
+  end
+
+  test 'no_results_link should use default I18N value if present and I8N value is not present' do
+    # Set Searcher Configuration value
+    QuickSearch::Engine::TEST_CONFIG = { 'no_results_link' => 'from config' }
+
+    # Set default I18N value
+    I18n.backend.store_translations(:en, {test_search: {default_no_results_link: 'from default I18N'} })
+
+    searcher = SearcherTest::TestSearcher.new
+
+    # Test i18n_key does not exist
+    no_results_link = searcher.no_results_link(
+      'test', 'nonexistent_i18n_key', 'test_search.default_no_results_link')
+    assert_equal 'from default I18N', no_results_link
+
+    # Test i18n_key is nil
+    no_results_link = searcher.no_results_link(
+      'test', nil, 'test_search.default_no_results_link')
+    assert_equal 'from default I18N', no_results_link
+  end
+
+  def teardown
+    # Clear TEST_CONFIG constant, if set
+    QuickSearch::Engine.send(:remove_const, 'TEST_CONFIG') if defined? QuickSearch::Engine::TEST_CONFIG
+
+    # Clear any I18n changes
+    I18n.backend.reload!
   end
 end
 


### PR DESCRIPTION
This pull request corrects an issue in the functionality of
Pull Request #23, where in the production environment
the "no_results_link" method fails to use the setting
in the search configuration file, even when no I18n keys
have been set.

The existing functionality worked correctly in the Rails
development environment, but not in the Rails production
environment, because of the I18n fallback behavior in
production.

In the development environment, the I18n functionality does not
"fallback" to a default if the given I18N key is not found, so a
"nil" is returned.

In the production environment, the Rails default is to have
"config.i18n.fallback" set to true, in which case a missing
I18N key causes a non-nil "translation missing" string to be returned.
Because the value was non-nil, it was causing the value from
the searcher configuration file to be ignored, even if the
I18N keys did not exist.

This change modifies the "no_results_link" method to verify that the
I18N key (and I18N default key, if given) actually exist, before using
them for the return value. This ensures that the value from the
searcher configuration file will be used if I18N keys do not exist.

Added additional tests to verify the expected behavior.

Also added "require_dependency 'search_error'" to the
"test/searcher/searcher_test.rb" so that tests would not
intermittently fail with the following error:

```
NameError: uninitialized constant QuickSearch::SearcherError
```

depending on the order in which they were run.