### PR TITLE
Replaced "primary_searcher_config" variable with "searcher_config"

### DIFF
--- a/app/controllers/concerns/quick_search/searcher_concern.rb
+++ b/app/controllers/concerns/quick_search/searcher_concern.rb
@@ -15,8 +15,6 @@ module QuickSearch::SearcherConcern
       search_threads = []
       @found_types = [] # add the types that are found to a navigation bar
 
-      primary_searcher_config = ''
-
       if primary_searcher == 'defaults'
         searchers = QuickSearch::Engine::APP_CONFIG['searchers']
       else
@@ -45,8 +43,8 @@ module QuickSearch::SearcherConcern
               # FIXME: Probably want to set paging and offset somewhere else.
               # searcher = klass.new(http_client, params_q_scrubbed, QuickSearch::Engine::APP_CONFIG['per_page'], 0, 1, on_campus?(request.remote_ip))
               if sm == primary_searcher
-                if primary_searcher_config.has_key? 'with_paging'
-                  per_page = primary_searcher_config['with_paging']['per_page']
+                if searcher_config.has_key? 'with_paging'
+                  per_page = searcher_config['with_paging']['per_page']
                 else
                   per_page = 10
                 end


### PR DESCRIPTION
The "primary_searcher_config" variable in the "search_all_in_threads" method of the "app/controllers/concerns/quick_search/searcher_concern.rb" file is causing all single searcher searches performed while the page is rendering to immediately fail. The SearcherError that is generated contains the message "undefined method `has_key?' for "":String". The variable is initialized as a String, and never assigned any other value. When a single searcher search is performed, the "has_key?" method is called, which will always fail, because the variable is a String, not a Hash.

This issue was uncovered while working with searchers that use a "loaded_link" method to return the URL to the native search interface, instead of the "loaded_link" property in the I18n en.yml file (see Pull Request #23). When using such a searcher, the above issue causes the rendering of the search results page to fail, because the searcher in the SearcherError object that gets created is "nil".

## Steps to Demonstrate

This issue can be  demonstrated using the Arxiv searcher (https://github.com/NCSU-Libraries/quick_search-arxiv_searcher)

QuickSearch provides "single searcher" searches using the <SERVER_URL>/searcher/<searcher> endpoint (for example, http://localhost:3000/searcher/arxiv).

When a search is run, the following will be immediately printed in the log:

```
FAILED SEARCH: arxiv | <query term>
```

where <query term> is the term being searched. A page of results will be displayed, but this is occurring because of the AJAX fallback, not as a result of the search done during rendering.

To demonstrate the problem when a searcher using the "loaded_link" functionality implemented in Pull Request #23 is used, edit the "quick_search-arxiv_searcher/config/locales/en.yml" file, and remove the "loaded_link" property. Then run the application and the single search again. This time an error page will be displayed.

## Implementation

It is unclear what the original intent of the "primary_searcher_config" variable was, but it seems similar to the existing "searcher_config" variable.

Replacing the "primary_searcher_config" variable with "searcher_config" enables single searcher searches to succeed, but I am not certain that this is the optimal solution. If there is a better solution, I am happy to make the requisite changes.
