### PR TITLE
Added search_cfg nil check for single searcher search page

### DIFF
--- a/app/controllers/quick_search/search_controller.rb
+++ b/app/controllers/quick_search/search_controller.rb
@@ -30,7 +30,12 @@ module QuickSearch
         additional_services = []
       end
       loaded_searches(additional_services)
-      @common_searches = searcher_cfg['common_searches'] || []
+
+      @common_searches = []
+      if searcher_cfg and searcher_cfg.has_key? 'common_searches'
+        @common_searches = searcher_cfg['common_searches']
+      end
+
       #TODO: maybe a default template for single-searcher searches?
       http_search(searcher_name, "quick_search/search/#{searcher_name}_search")
     end


### PR DESCRIPTION
Fixed an issue where the single searcher search page displays an error for searchers without an explicit "config/<searcher>_config.yml" configuration file.

## Steps to Demonstrate

This issue can be demonstrated using the Wikipedia searcher (https://github.com/ncsu-libraries/quick_search-wikipedia_searcher)

QuickSearch provides "single searcher" searches using the <SERVER_URL>/searcher/ endpoint (for example, http://localhost:3000/searcher/wikipedia).

When going to http://localhost:3000/searcher/wikipedia, and error page is shown with the following error:

```
NoMethodError in QuickSearch::SearchController#single_searcher 

undefined method `[]' for nil:NilClass
```

This problem only occurs for searcher without an explicit "config/<searcher>_config.yml" configuration file.

## Issue Implementation

The cause of the error is not handling the possibility that the "search_cfg" variable may be nil. This is likely just an oversight, as a nil check is performed in elsewhere in the method.

Modified the code to provide "@common_searches" with a default value, which can then be overwritten if the "search_cfg" variable contains the "common_searches" key.
