### PR TITLE
Pass Best Bet keywords through "filter_query" method

### DIFF
--- a/lib/quick_search/engine.rb
+++ b/lib/quick_search/engine.rb
@@ -11,7 +11,7 @@ module QuickSearch
     #
     # This way, we can make application specific overrides of views, otherwise fall back to theme,
     # and finally fall back to the QS core if needed.
-    
+
     initializer :quick_search, :after => :add_view_paths do
       config_file = File.join(Rails.root, "/config/quick_search_config.yml")
       if File.exist?(config_file)
@@ -44,12 +44,28 @@ module QuickSearch
     initializer :best_bets, :after => :quick_search do
       if defined? QuickSearch::Engine::APP_CONFIG and QuickSearch::Engine::APP_CONFIG['best_bets']['solr_url'].empty?
         best_bets_file = File.join(Rails.root, "/config/best_bets.yml")
+
         if File.exist?(best_bets_file)
+
+          # Helper class for enabling access to the "filter_query" method
+          # in QuickSearch::QueryFilter concern
+          class BestBetFilter
+            include QuickSearch::QueryFilter
+
+            def filter(keyword)
+              filter_query(keyword)
+            end
+          end
+
+          best_bet_filter = BestBetFilter.new
           QuickSearch::Engine::BEST_BETS = YAML.load_file(best_bets_file)['best_bets']
           QuickSearch::Engine::BEST_BETS_INDEX = {}
           QuickSearch::Engine::BEST_BETS.each do |best_bet_name, best_bet|
             QuickSearch::Engine::BEST_BETS[best_bet_name]['id'] = best_bet_name
             best_bet['keywords'].each do |keyword|
+              # Pass keyword through "filter_query" method so that keyword
+              # will match query term passed through the same method
+              keyword = best_bet_filter.filter(keyword)
               QuickSearch::Engine::BEST_BETS_INDEX[keyword.downcase] = best_bet_name
             end
           end

--- a/test/dummy/config/best_bets.yml
+++ b/test/dummy/config/best_bets.yml
@@ -84,3 +84,9 @@ best_bets:
     keywords:
     - pubmed
     - pub med
+  testbestbetdash:
+    title: Test Best Bet Entry with Dash in Keyword
+    description: This is a test Best Bet entry to test keywords containing a dash
+    url: http://example.org
+    keywords:
+    - 123-456

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   mount QuickSearch::Engine => "/"
 
   root :to => 'quick_search/search#index'
+  get 'xhr_search' => 'quick_search/search#xhr_search', :defaults => { :format => 'html' }
 end

--- a/test/integration/best_bets_initializer_test.rb
+++ b/test/integration/best_bets_initializer_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class BestBestInitializerTest < ActionDispatch::IntegrationTest
+  test 'best bet keyword with dash should be found' do
+    # Clear the solr_url so we don't try to get Best Bet from Solr
+    QuickSearch::Engine::APP_CONFIG['best_bets']['solr_url'] = ''
+
+    # Keyword for "testbestbet" entry in test/dummy/config/best_bets.yml
+    visit xhr_search_path(q: '123-456', endpoint: 'best_bets', format: 'json')
+
+    json = JSON.parse(page.html)
+    first_result = json['results'][0]
+    assert_equal 'testbestbetdash', first_result['id']
+  end
+end


### PR DESCRIPTION
Query terms entered by the user are passed through the "filter_query" method in the "QuickSearch::QueryFilter" concern to remove problematic characters such as dashes/asterisks/exclamation points, as well as converting the query term to lower-case.

This modification changes the Best Bet initializer to pass the keywords through the same "filter_query" method. This ensures that keywords with problematic characters are treated in the same way as query terms. Without this change, any keyword with a dash/asterisk/exclamation point, or upper-case  letter would never be matched.

We have encountered this problem in practice, when attempting to use ISSN numbers (which include dashes) as keywords for serial publications.

## Implementation Notes

The implementation modifies the "lib/quick_search/engine.rb" class to pass each Best Bet keyword from the "config/best_bets.yml" file through the "filter_query" method in the "QuickSearch::QueryFilter" concern.

The implementation was somewhat complicated by the fact that the "filter_query" method is a private method on a Rails concern. This was handled by creating a helper class in the initializer that delegates to the concern. Not sure if this was really the "Ruby way" to do this, but it does appear to work -- any suggestions for improvement are welcome.

For unit testing, modified "test/dummy/config/best_bets.yml" to add a new Best Bet entry with a keyword including a dash for use by "test/integration/best_bets_initializer_test.rb"

Also added the "xhr_search" route to "test/dummy/config/routes.rb" so it would be available as a "*_path" helper in the test.